### PR TITLE
Fix packetizing packages whith _ and -

### DIFF
--- a/packetizer.py
+++ b/packetizer.py
@@ -274,12 +274,18 @@ class Packetizer:
         with open(target, 'wb') as fp:
             fp.write(content)
         package.archive = target
+        if not package.package in package.archive:
+            # package is not named like archive
+            package.package = self._extract_package_from_archive(package.archive)
         logger.info('Downloading sources: %s downloaded', package.archive)
 
         logger.info('Unpacking sources: %s...', package.archive)
         shutil.unpack_archive(os.path.join(self.sources, package.archive), self.temp)
         package.sources = os.path.join(self.temp, '%s-%s' % (package.package, package.version))
         logger.info('Unpacking sources: %s unpacked', package.sources)
+
+    def _extract_package_from_archive(self, archive: str) -> str:
+        return '-'.join(os.path.basename(archive).split('-')[:-1])
 
     def _build_package_spec(self, package: Package):
         """


### PR DESCRIPTION
not working example

```
[root@6ef44226a3ed /]# /usr/local/bin/python3.7 -m packetizer --prefix 'trg-python37-' --recursive 'prometheus-client'
Activating virtualenv: /root/rpmbuild/PYTHON/venv
Building RPM spec for prometheus-client
Installing package: prometheus-client...
Querying version: prometheus-client...
Querying version: prometheus-client==0.7.1 installed
Querying dependencies: prometheus-client==0.7.1...
Querying sources: prometheus-client==0.7.1...
Querying sources: https://files.pythonhosted.org/packages/b3/23/41a5a24b502d35a4ad50a5bb7202a5e1d9a0364d0c12f56db3dbf7aca76d/prometheus_client-0.7.1.tar.gz found
Downloading sources: prometheus-client
Downloading sources: /root/rpmbuild/SOURCES/prometheus_client-0.7.1.tar.gz downloaded
Unpacking sources: /root/rpmbuild/SOURCES/prometheus_client-0.7.1.tar.gz...
Unpacking sources: /root/rpmbuild/PYTHON/temp/prometheus-client-0.7.1 unpacked
Building SPEC file: /root/rpmbuild/PYTHON/temp/prometheus-client-0.7.1...
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/usr/local/lib/python3.7/site-packages/packetizer.py", line 365, in <module>
    main()
  File "/usr/local/lib/python3.7/site-packages/packetizer.py", line 361, in main
    packetizer.packetize(package, verexpr, args.recursive, args.exclude)
  File "/usr/local/lib/python3.7/site-packages/packetizer.py", line 134, in packetize
    self._build_package_spec(package)
  File "/usr/local/lib/python3.7/site-packages/packetizer.py", line 293, in _build_package_spec
    check_output(command, cwd=package.sources)
  File "/usr/local/lib/python3.7/site-packages/packetizer.py", line 313, in check_output
    return subprocess.check_output(command, **kwargs)
  File "/usr/local/lib/python3.7/subprocess.py", line 395, in check_output
    **kwargs).stdout
  File "/usr/local/lib/python3.7/subprocess.py", line 472, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/usr/local/lib/python3.7/subprocess.py", line 775, in __init__
    restore_signals, start_new_session)
  File "/usr/local/lib/python3.7/subprocess.py", line 1522, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: '/root/rpmbuild/PYTHON/temp/prometheus-client-0.7.1': '/root/rpmbuild/PYTHON/temp/prometheus-client-0.7.1'
```